### PR TITLE
Fixed brew install script & updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ A simple web crawler for generating sitemaps and reporting errors.
 ## Install
 
 ```bash
-brew install https://raw.github.com/fd/butler/master/homebrew/butler.rb
+brew install https://raw.github.com/fd/butler-standalone/master/homebrew/butler.rb
 ```

--- a/homebrew/butler.rb
+++ b/homebrew/butler.rb
@@ -1,9 +1,9 @@
 require 'formula'
 
 class Butler < Formula
-  url 'https://raw.github.com/fd/butler/master/homebrew/butler-0.0.2.tar.gz'
-  homepage 'http://github.com/fd/butler'
-  md5 'b2b54121ff705b502ca25e01df98bc35'
+  url 'https://github.com/fd/butler-standalone/raw/master/homebrew/butler-0.0.2.tar.gz'
+  homepage 'https://github.com/fd/butler-standalone'
+  sha256 '2a277342e6e047e73111d04a9f4e7a8a14948a65348cd09351360abee5b93e19'
 
   skip_clean ['bin']
 


### PR DESCRIPTION
The path in the brew install script were pointing to an old repo.
